### PR TITLE
Support for primitive return type method signatures

### DIFF
--- a/Dixie/Dixie/ChaosProvider/ConstantChaosProvider/DixieConstantChaosProvider.m
+++ b/Dixie/Dixie/ChaosProvider/ConstantChaosProvider/DixieConstantChaosProvider.m
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 #import "DixieConstantChaosProvider.h"
+#import "NSObject+DixieRunTimeHelper.h"
 
 @interface DixieConstantChaosProvider()
 
@@ -31,7 +32,17 @@
 
 -(void) chaosImplementationFor:(id)victim environment:(DixieCallEnvironment *)environment
 {
-	environment.returnValue = (__bridge void *)(self.constant);
+    if(isType(self.context.methodInfo.signature.methodReturnType, void) == NO)
+    {
+        if(isType(self.context.methodInfo.signature.methodReturnType, id) ||
+           strcmp(self.context.methodInfo.signature.methodReturnType, "@?") == 0)
+        {
+            environment.returnValue = (__bridge void *)(self.constant);
+        }
+        else{
+            environment.returnValue = [(NSObject *)self.constant originalValue];
+        }
+    }
 }
 
 @end

--- a/Dixie/Dixie/ChaosProvider/ConstantChaosProvider/DixieConstantChaosProvider.m
+++ b/Dixie/Dixie/ChaosProvider/ConstantChaosProvider/DixieConstantChaosProvider.m
@@ -31,7 +31,7 @@
 
 -(void) chaosImplementationFor:(id)victim environment:(DixieCallEnvironment *)environment
 {
-	environment.returnValue = self.constant;
+	environment.returnValue = (__bridge void *)(self.constant);
 }
 
 @end

--- a/Dixie/Dixie/ChaosProvider/DixieBaseChaosProvider.m
+++ b/Dixie/Dixie/ChaosProvider/DixieBaseChaosProvider.m
@@ -22,13 +22,14 @@
                                                   environment:^(id victim, DixieCallEnvironment *environment) {
         
         [self chaosImplementationFor:victim environment:environment];
-        
-        [[DixieLogger defaultLogger] log:@"Puppet %@: %@ used %@ to return %@",
-         NSStringFromClass([victim class]),
-         NSStringFromSelector(self.context.methodInfo.selector),
-         [self class],
-         environment.returnValue];
-        
+        if(isType(self.context.methodInfo.signature.methodReturnType, id))
+        {
+            [[DixieLogger defaultLogger] log:@"Puppet %@: %@ used %@ to return %@",
+             NSStringFromClass([victim class]),
+             NSStringFromSelector(self.context.methodInfo.selector),
+             [self class],
+             environment.returnValue];
+        }
     }];
 }
 

--- a/Dixie/Dixie/ChaosProvider/NonChaosProvider/DixieNonChaosProvider.m
+++ b/Dixie/Dixie/ChaosProvider/NonChaosProvider/DixieNonChaosProvider.m
@@ -20,4 +20,9 @@
 	return self.context.originalIMP;
 }
 
+-(void) chaosImplementationFor:(id)victim environment:(DixieCallEnvironment *)environment
+{
+    [DixieRunTimeHelper callImplementation:self.context.originalIMP on:victim chaosContext:self.context environment:environment];
+}
+
 @end

--- a/Dixie/Dixie/ChaosProvider/RandomChaosProvider/DixieRandomChaosProvider.m
+++ b/Dixie/Dixie/ChaosProvider/RandomChaosProvider/DixieRandomChaosProvider.m
@@ -39,6 +39,6 @@
 
 -(void) chaosImplementationFor:(id)victim environment:(DixieCallEnvironment *)environment
 {
-    environment.returnValue = [self.paramProvider parameter];
+    environment.returnValue = (__bridge void *)([self.paramProvider parameter]);
 }
 @end

--- a/Dixie/Dixie/Runtime/DixieCallEnvironment.h
+++ b/Dixie/Dixie/Runtime/DixieCallEnvironment.h
@@ -26,7 +26,7 @@
 /**
  *  The return value of a method's implementation
  */
-@property (nonatomic) id returnValue;
+@property (nonatomic) void *returnValue;
 
 /**
  *  Creates a DixieCallEnvironment with the arguments

--- a/Dixie/Dixie/Runtime/DixieRunTimeHelper.h
+++ b/Dixie/Dixie/Runtime/DixieRunTimeHelper.h
@@ -20,6 +20,8 @@
 
 #define DixieMethodPrefix @"dixie_"
 
+#define isType(typeEncoding, type2) (strcmp(typeEncoding, @encode(type2)) == 0)
+
 /**
  *  Block type to describe a method's concrete implementation
  *

--- a/Dixie/Dixie/Runtime/DixieRunTimeHelper.m
+++ b/Dixie/Dixie/Runtime/DixieRunTimeHelper.m
@@ -97,6 +97,8 @@ struct Block {
     if (isType(rType, double)) return BLOCK(double);
     if (isType(rType, float)) return BLOCK(float);
     if (isType(rType, long)) return BLOCK(long);
+    if (isType(rType, short)) return BLOCK(short);
+    if (isType(rType, unsigned int)) return BLOCK(unsigned int);
     
     return BLOCK_ID;
 }

--- a/Dixie/Dixie/Runtime/DixieRunTimeHelper.m
+++ b/Dixie/Dixie/Runtime/DixieRunTimeHelper.m
@@ -14,14 +14,6 @@
 #import "DixieRunTimeHelper.h"
 #import "NSObject+DixieRunTimeHelper.h"
 
-#define isType(type1, type2) (strcmp(type1, @encode(type2)) == 0)
-
-#define storeOriginal(object , type, original)       \
-({                                                   \
-object.originalValue = (void*)malloc(sizeof(type));  \
-((type*)object.originalValue)[0] = original;         \
-})                                                   \
-
 @interface NSInvocation (PrivateHack)
 - (void)invokeUsingIMP: (IMP)imp;
 @end
@@ -74,47 +66,44 @@ struct Block {
  */
 +(id) blockForSignature:(NSMethodSignature*)signature block:(DixieImplementationBlock)block
 {
+#define BLOCK_ID                                                                                        \
+    ^id(id victim, ...){                                                                                \
+        va_list args;                                                                                   \
+        va_start(args, victim);                                                                         \
+                                                                                                        \
+        NSArray* arguments = [self argumentsFor:signature originalArguments:args];                      \
+        DixieCallEnvironment* environment = [[DixieCallEnvironment alloc] initWithArguments:arguments]; \
+        block(victim, environment);                                                                     \
+        return environment.returnValue;                                                                 \
+    }
+    
+#define BLOCK(TYPE)                                                                                     \
+    ^TYPE(id victim, ...){                                                                              \
+        va_list args;                                                                                   \
+        va_start(args, victim);                                                                         \
+                                                                                                        \
+        NSArray* arguments = [self argumentsFor:signature originalArguments:args];                      \
+        DixieCallEnvironment* environment = [[DixieCallEnvironment alloc] initWithArguments:arguments]; \
+        block(victim, environment);                                                                     \
+        return *(TYPE *)environment.returnValue;                                                        \
+    }
+    
     const char* rType = signature.methodReturnType;
     
-    if (isType(rType, void))
-    {
-        return ^void(id victim, ...){ \
-            
-            va_list args;
-            va_start(args, victim);
-            
-            NSArray* arguments = [self argumentsFor:signature originalArguments:args];
-            
-            va_end(args);
-            
-            DixieCallEnvironment* environment = [[DixieCallEnvironment alloc] initWithArguments:arguments];
-            
-            block(victim, environment);
-        };
-    }
-    else
-    {
-        return ^id (id victim, ...){ \
-            
-            va_list args;
-            va_start(args, victim);
-            
-            NSArray* arguments = [self argumentsFor:signature originalArguments:args];
-            
-            va_end(args);
-            
-            DixieCallEnvironment* environment = [[DixieCallEnvironment alloc] initWithArguments:arguments];
-            
-            block(victim, environment);
-            
-            return environment.returnValue;
-        };
-    }
+    if (isType(rType, void)) return BLOCK(void);
+    if (isType(rType, BOOL)) return BLOCK(BOOL);
+    if (isType(rType, int)) return BLOCK(int);
+    if (isType(rType, char)) return BLOCK(char);
+    if (isType(rType, double)) return BLOCK(double);
+    if (isType(rType, float)) return BLOCK(float);
+    if (isType(rType, long)) return BLOCK(long);
+    
+    return BLOCK_ID;
 }
 
 /**
- *  Parses a variadic list into array of objects 
-    @note The current solution handles only object,selector,BOOL and char types.
+ *  Parses a variadic list into array of objects
+ @note The current solution handles only object,selector,BOOL and char types.
  *
  *  @param signature The signature to determine the type of parameters in the variadic list
  *  @param arguments The variadic list
@@ -126,6 +115,8 @@ struct Block {
     //Ignore self and _cmd
     NSInteger numberOfParameters = signature.numberOfArguments-2;
     NSMutableArray* parameters = [NSMutableArray arrayWithCapacity:numberOfParameters];
+    va_list iteratorList;
+    __va_copy(iteratorList, arguments);
     
     for (NSInteger index = 0; index < numberOfParameters; index++) {
         
@@ -133,7 +124,7 @@ struct Block {
         const char* argTyp = [signature getArgumentTypeAtIndex:index + 2];
         
         //Convert to object
-        id parameter = [self objectFromNext:arguments type:argTyp];
+        id parameter = [self objectFromNext:iteratorList type:argTyp outputArgumentList:&iteratorList];
         
         //Fill the unparsed value with NSNull
         parameter = parameter ? :[NSNull null];
@@ -151,7 +142,7 @@ struct Block {
     
     [invocation setTarget:puppet];
     [invocation setSelector:chaosContext.methodInfo.selector];
-
+    
     //We are ignoring the index of self and _cmd
     for (NSInteger i = 2; i < signature.numberOfArguments; i++) {
         
@@ -175,12 +166,20 @@ struct Block {
     }
     
     [invocation invokeUsingIMP:implementation];
-
+    
     if (!isType(chaosContext.methodInfo.signature.methodReturnType, void))
     {
-        __unsafe_unretained id returnValue;
-        [invocation getReturnValue:&returnValue];
-        environment.returnValue = returnValue;
+        if(isType(chaosContext.methodInfo.signature.methodReturnType, id))
+        {
+            id returnValue;
+            [invocation getReturnValue:&returnValue];
+            environment.returnValue = (void*)CFBridgingRetain(returnValue);
+        }
+        else
+        {
+            void *returnValue = malloc(chaosContext.methodInfo.signature.methodReturnLength);
+            environment.returnValue = returnValue;
+        }
     }
 }
 
@@ -190,11 +189,12 @@ struct Block {
  *  @note We are using core foundation factories here, NSNumber, NSString might be swizzled
  *
  *  @param arguments The variadic list
- *  @param argType   the expected type of the next item
+ *  @param argType   The expected type of the next item
+ *  @param ova_List  The current state of the variadic list after the current value is read from it
  *
  *  @return An NSObject subclass that represents the argument
  */
-+(id) objectFromNext:(va_list)arguments type:(const char*)argType
++(NSObject *) objectFromNext:(va_list)arguments type:(const char*)argType outputArgumentList:(out void *)ova_List
 {
     NSObject* object;
     
@@ -280,13 +280,13 @@ struct Block {
     }
     //Object
     else if (strcmp(argType, "@") == 0   ||//NSObject
-        strcmp(argType, "no@") == 0 || //NSObject?
-        strcmp(argType, "@?") == 0  //Block
-        )
+             strcmp(argType, "no@") == 0 || //NSObject?
+             strcmp(argType, "@?") == 0  //Block
+             )
     {
         id data = va_arg(arguments, id);
         
-        object = data;
+        object = strcmp(argType, "@?") == 0 ? [data copy] : data;
     }
     //class
     else if (isType(argType, Class))
@@ -316,6 +316,8 @@ struct Block {
     
     //Set the original encoding on the object
     [object setEncoding:[NSString stringWithUTF8String:argType]];
+    
+    ova_List = &arguments;
     
     return object;
 }

--- a/Dixie/Dixie/Runtime/NSObject+DixieRunTimeHelper.h
+++ b/Dixie/Dixie/Runtime/NSObject+DixieRunTimeHelper.h
@@ -13,6 +13,12 @@
 
 @import Foundation;
 
+#define storeOriginal(object , type, original)       \
+({                                                   \
+object.originalValue = (void*)malloc(sizeof(type));  \
+((type*)object.originalValue)[0] = original;         \
+})                                                   \
+
 /**
  *  Helper category on NSObject to store the original type encoding and value if the object was converted from non-object type
  */

--- a/Dixie/DixieTests/Helpers/ChaosProviderTestClass.h
+++ b/Dixie/DixieTests/Helpers/ChaosProviderTestClass.h
@@ -18,5 +18,6 @@
 - (id)returnValue;
 -(NSNumber*) numberFromInteger:(int)integer;
 -(NSString*) variadicMethod:(id)key,... NS_REQUIRES_NIL_TERMINATION;
+-(int) returnIntValue;
 
 @end

--- a/Dixie/DixieTests/Helpers/ChaosProviderTestClass.h
+++ b/Dixie/DixieTests/Helpers/ChaosProviderTestClass.h
@@ -12,12 +12,44 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CGGeometry.h>
 
+typedef int(^TestBlockType)(double, BOOL);
+
+@protocol ChaosProviderTestClassDelegate <NSObject>
+
+-(BOOL) isItTrue;
+
+@end
+
+/*!
+ A class to test various method types
+ */
 @interface ChaosProviderTestClass : NSObject
 
-- (id)returnValue;
+@property (nonatomic, weak) id<ChaosProviderTestClassDelegate> testDelegate;
+
+-(id) returnValue;
 -(NSNumber*) numberFromInteger:(int)integer;
 -(NSString*) variadicMethod:(id)key,... NS_REQUIRES_NIL_TERMINATION;
 -(int) returnIntValue;
 
++(void) classDoNothing;
+-(void) throwException;
+-(void) doNothing;
+
+-(void) setNumber:(int)number object:(NSNumber *)numberObj block:(dispatch_block_t)block;
+-(void) setChar:(char)aChar frame:(CGRect)frame;
+
+-(id) arg1:(NSNumber *)arg1 arg2:(NSInteger)arg2 arg3:(double)arg3 arg4:(float)arg4 arg5:(int)arg5 arg6:(int*)arg6 arg7:(BOOL)arg7 arg8:(char)arg8 arg9:(short)arg9 arg10:(long)arg10;
+-(float) valueFrom:(double)doubleValue;
+-(TestBlockType) block;
+
 @end
+
+@interface ChaosProviderTestClass(aCategory)
+
+-(unsigned int) randomIntFrom:(int)k;
+
+@end
+

--- a/Dixie/DixieTests/Helpers/ChaosProviderTestClass.m
+++ b/Dixie/DixieTests/Helpers/ChaosProviderTestClass.m
@@ -15,6 +15,20 @@
 
 @implementation ChaosProviderTestClass
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        
+    }
+    return self;
+}
+
++ (void)classDoNothing
+{
+    
+}
+
 -(id)returnValue
 {
     return @2;
@@ -35,4 +49,54 @@
     return 42;
 }
 
+- (void)throwException
+{
+    @throw [NSException exceptionWithName:@"Test" reason:@"Arbitrary reason" userInfo:nil];
+}
+
+- (void)doNothing
+{
+    
+}
+
+-(void) setNumber:(int)number object:(NSNumber *)numberObj block:(dispatch_block_t)block;
+{
+    
+}
+
+-(void) setChar:(char)aChar frame:(CGRect)frame
+{
+    
+}
+
+-(short) _veryPrivateMethod
+{
+    return 0;
+}
+
+-(id) arg1:(NSNumber *)arg1 arg2:(NSInteger)arg2 arg3:(double)arg3 arg4:(float)arg4 arg5:(int)arg5 arg6:(int*)arg6 arg7:(BOOL)arg7 arg8:(char)arg8 arg9:(short)arg9 arg10:(long)arg10
+{
+    return [@(arg1.integerValue + arg2 + arg3 + arg4 + arg5 + *arg6 + arg7 +arg8 + arg9 + arg10) stringValue];
+}
+
+-(float) valueFrom:(double)doubleValue
+{
+    return [@(doubleValue) floatValue];
+}
+
+-(TestBlockType) block
+{
+    return ^int(double d, BOOL b){ return b ? d : 42;};
+}
+
 @end
+
+@implementation ChaosProviderTestClass (aCategory)
+
+-(unsigned int) randomIntFrom:(int)k
+{
+    return arc4random_uniform(k);
+}
+
+@end
+

--- a/Dixie/DixieTests/Helpers/ChaosProviderTestClass.m
+++ b/Dixie/DixieTests/Helpers/ChaosProviderTestClass.m
@@ -30,4 +30,9 @@
     return @"";
 }
 
+-(int)returnIntValue
+{
+    return 42;
+}
+
 @end

--- a/Dixie/DixieTests/Helpers/TestClass.h
+++ b/Dixie/DixieTests/Helpers/TestClass.h
@@ -20,7 +20,6 @@
 
 - (id)returnValue;
 - (int)returnIntValue;
-- (void)throwException;
 - (void)doNothing;
 
 -(void) setNumber:(int)number object:(NSNumber *)numberObj block:(dispatch_block_t)block;

--- a/Dixie/DixieTests/Helpers/TestClass.h
+++ b/Dixie/DixieTests/Helpers/TestClass.h
@@ -19,9 +19,11 @@
 + (void)classDoNothing;
 
 - (id)returnValue;
+- (int)returnIntValue;
 - (void)throwException;
 - (void)doNothing;
 
+-(void) setNumber:(int)number object:(NSNumber *)numberObj block:(dispatch_block_t)block;
 -(void) setChar:(char)aChar frame:(CGRect)frame;
 
 @end

--- a/Dixie/DixieTests/Helpers/TestClass.m
+++ b/Dixie/DixieTests/Helpers/TestClass.m
@@ -30,17 +30,12 @@
     return 42;
 }
 
-- (void)throwException
-{
-    @throw [NSException exceptionWithName:@"Test" reason:@"Arbitrary reason" userInfo:nil];
-}
-
 - (void)doNothing
 {
     
 }
 
--(void) setNumber:(int)number object:(NSNumber *)numberObj block:(BOOL(^)(void))block
+-(void) setNumber:(int)number object:(NSNumber *)numberObj block:(dispatch_block_t)block;
 {
     
 }

--- a/Dixie/DixieTests/Helpers/TestClass.m
+++ b/Dixie/DixieTests/Helpers/TestClass.m
@@ -25,12 +25,22 @@
     return @2;
 }
 
+- (int)returnIntValue
+{
+    return 42;
+}
+
 - (void)throwException
 {
     @throw [NSException exceptionWithName:@"Test" reason:@"Arbitrary reason" userInfo:nil];
 }
 
 - (void)doNothing
+{
+    
+}
+
+-(void) setNumber:(int)number object:(NSNumber *)numberObj block:(BOOL(^)(void))block
 {
     
 }

--- a/Dixie/DixieTests/Units/DixieChaosProviderTests.m
+++ b/Dixie/DixieTests/Units/DixieChaosProviderTests.m
@@ -17,7 +17,7 @@
 #import "ChaosProviderTestClass.h"
 #import "NSObject+DixieRunTimeHelper.h"
 
-@interface DixieChaosProviderTests : XCTestCase
+@interface DixieChaosProviderTests : XCTestCase <ChaosProviderTestClassDelegate>
 {
     Dixie* dixie;
 }
@@ -232,6 +232,21 @@
     XCTAssert([string isEqualToString:@""], @"Original variadic function should be called");
 }
 
+-(void) testVariadicStubbed
+{
+    //GIVEN
+    DixieConstantChaosProvider *provider = [DixieConstantChaosProvider constant:@"Hello"];
+    DixieProfileEntry *entry = [DixieProfileEntry entry:[ChaosProviderTestClass class] selector:@selector(variadicMethod:) chaosProvider:provider];
+    
+    dixie.Profile(entry).Apply();
+    
+    //WHEN
+    NSString *string = [[ChaosProviderTestClass new] variadicMethod:@"key",@2,nil];
+    
+    //THEN
+    XCTAssert([string isEqualToString:@"Hello"], @"Wrong return value for variadic stubbing");
+}
+
 #pragma mark - Primitives
 -(void) testChaosForPrimitiveReturnType
 {
@@ -286,4 +301,148 @@
     XCTAssert([number isEqualToNumber:@11], @"New int value should be returned");
 }
 
+#pragma mark - Method type fuzzing
+-(void) testPropertyGetterSetterChanged
+{
+    //GIVEN
+    DixieBlockChaosProvider *setterBlockProvider = [DixieBlockChaosProvider block:^(DixieBaseChaosProvider *chaosProvider, id victim, DixieCallEnvironment *environment) {
+        //THEN
+        XCTAssert(environment.arguments.firstObject == self, @"First argument is invalid");
+    }];
+    
+    DixieBlockChaosProvider *getterBlockProvider = [DixieBlockChaosProvider block:^(DixieBaseChaosProvider *chaosProvider, id victim, DixieCallEnvironment *environment) {
+        environment.returnValue = (__bridge void *)(self);
+    }];
+    
+    DixieProfileEntry *setterEntry = [DixieProfileEntry entry:[ChaosProviderTestClass class] selector:@selector(setTestDelegate:) chaosProvider:setterBlockProvider];
+    DixieProfileEntry *getterEntry = [DixieProfileEntry entry:[ChaosProviderTestClass class] selector:@selector(testDelegate) chaosProvider:getterBlockProvider];
+    
+    ChaosProviderTestClass *testObject = [ChaosProviderTestClass new];
+
+    //WHEN
+    dixie.Profile(setterEntry).Apply();
+    
+    [testObject setTestDelegate:self];
+    
+    dixie.RevertIt(setterEntry);
+    
+    [testObject setTestDelegate:nil];
+    
+    dixie.Profile(getterEntry).Apply();
+    
+    //THEN
+    XCTAssert(testObject.testDelegate == self, @"Getter property invalid");
+}
+
+-(void) testPrivateMethodChanged
+{
+    //GIVEN
+    short original = 2;
+    NSNumber *number = @2;
+    storeOriginal(number, short, original);
+    DixieConstantChaosProvider *provider = [DixieConstantChaosProvider constant:number];
+    
+    dixie
+        .Profile([DixieProfileEntry entry:[ChaosProviderTestClass class] selector:NSSelectorFromString(@"_veryPrivateMethod") chaosProvider:provider])
+        .Apply();
+    
+    //WHEN
+    NSNumber *value = [[ChaosProviderTestClass new] valueForKeyPath:@"_veryPrivateMethod"];
+    
+    //THEN
+    XCTAssert([value isEqualToNumber:@2], @"Private method is not changed");
+}
+
+-(void) testUltimateMethodChanged
+{
+    //GIVEN
+    DixieNilChaosProvider *provider = [DixieNilChaosProvider new];
+    DixieProfileEntry *entry = [DixieProfileEntry entry:[ChaosProviderTestClass class] selector:@selector(arg1:arg2:arg3:arg4:arg5:arg6:arg7:arg8:arg9:arg10:) chaosProvider:provider];
+    
+    dixie.Profile(entry).Apply();
+    
+    //WHEN
+    int arg6 = 2;
+    id value = [[ChaosProviderTestClass new] arg1:@2 arg2:2 arg3:2.0 arg4:2.f arg5:2 arg6:&arg6 arg7:NO arg8:'a' arg9:5 arg10:67l];
+    
+    //THEN
+    XCTAssert(value == nil,@"Ultimate method not changed");
+}
+
+-(void) testUseBlockParameterOfMethod
+{
+    //GIVEN
+    __block BOOL called = NO;
+    dispatch_block_t aBlock = ^{called = YES;};
+    
+    DixieBlockChaosProvider *blockProvider = [DixieBlockChaosProvider block:^(DixieBaseChaosProvider *chaosProvider, id victim, DixieCallEnvironment *environment) {
+        dispatch_block_t block = environment.arguments[2];
+        
+        block();
+    }];
+    DixieProfileEntry *entry = [DixieProfileEntry entry:[ChaosProviderTestClass class] selector:@selector(setNumber:object:block:) chaosProvider:blockProvider];
+    
+    dixie.Profile(entry).Apply();
+    
+    //WHEN
+    [[ChaosProviderTestClass new] setNumber:2 object:@2 block:aBlock];
+    
+    //THEN
+    XCTAssert(called == YES, @"Block parameter of method is not called");
+}
+
+-(void) testUseBlockReturnType
+{
+    //GIVEN
+    DixieConstantChaosProvider *provider = [DixieConstantChaosProvider constant:[^int(double d, BOOL b){return (int)b;} copy]];
+    DixieProfileEntry *entry = [DixieProfileEntry entry:[ChaosProviderTestClass class] selector:@selector(block) chaosProvider:provider];
+    
+    dixie.Profile(entry).Apply();
+    
+    //WHEN
+    TestBlockType block = [[ChaosProviderTestClass new] block];
+    
+    //THEN
+    XCTAssert(block(0.4,YES) == 1, @"Wrong block returned");
+}
+
+-(void) testCategoryMethodChanged
+{
+    //GIVEN
+    unsigned int k = 103;
+    NSNumber *number = @(k);
+    storeOriginal(number, unsigned int, k);
+    DixieProfileEntry *entry = [DixieProfileEntry entry:[ChaosProviderTestClass class] selector:@selector(randomIntFrom:) chaosProvider:[DixieConstantChaosProvider constant:number]];
+    
+    dixie.Profile(entry).Apply();
+    
+    //WHEN
+    unsigned int n = [[ChaosProviderTestClass new] randomIntFrom:4];
+    
+    //THEN
+    XCTAssert(n == k, @"Category method is not changed");
+}
+
+- (void)testProtocolParamUsed
+{
+    //GIVEN
+    __block BOOL answer = NO;
+    DixieBlockChaosProvider *setterBlockProvider = [DixieBlockChaosProvider block:^(DixieBaseChaosProvider *chaosProvider, id victim, DixieCallEnvironment *environment) {
+        answer = [(id<ChaosProviderTestClassDelegate>)environment.arguments.firstObject isItTrue];
+    }];
+    DixieProfileEntry *setterEntry = [DixieProfileEntry entry:[ChaosProviderTestClass class] selector:@selector(setTestDelegate:) chaosProvider:setterBlockProvider];
+    dixie.Profile(setterEntry).Apply();
+    
+    //WHEN
+    [[ChaosProviderTestClass new] setTestDelegate:self];
+    
+    //THEN
+    XCTAssert(answer == YES, @"Protocol parameter could not be used");
+}
+
+#pragma mark - ChaosProviderTestClassDelegate
+-(BOOL) isItTrue
+{
+    return YES;
+}
 @end

--- a/Dixie/DixieTests/Units/RunTimeHelperTests.m
+++ b/Dixie/DixieTests/Units/RunTimeHelperTests.m
@@ -17,7 +17,7 @@
 
 @interface DixieRunTimeHelper(UnitTest)
 +(NSArray*) argumentsFor:(NSMethodSignature*)signature originalArguments:(va_list)arguments;
-+(id) objectFromNext:(va_list)arguments type:(const char*)argType;
++(id) objectFromNext:(va_list)arguments type:(const char*)argType outputArgumentList:(out void *)oVa_List;
 +(id) blockForSignature:(NSMethodSignature*)signature block:(DixieImplementationBlock)block;
 @end
 
@@ -66,7 +66,7 @@
     [DixieRunTimeHelper callImplementation:implementation on:[TestClass new] chaosContext:context environment:environment];
     
     //Then
-    XCTAssert([environment.returnValue isEqualToNumber:@2], @"IMP should be called correctly");
+    XCTAssert([(NSNumber *)environment.returnValue isEqualToNumber:@2], @"IMP should be called correctly");
 }
 
 -(void)testClassVoidImplementationIsCalled
@@ -96,7 +96,7 @@
         va_list arguments;
         va_start(arguments, encoding);
         
-        id object = [DixieRunTimeHelper objectFromNext:arguments type:encoding];
+        id object = [DixieRunTimeHelper objectFromNext:arguments type:encoding outputArgumentList:arguments];
         
         va_end(arguments);
         
@@ -143,6 +143,25 @@
     }(@"Input value:",'c', CGRectMake(0, 0, 0, 0));
 }
 
+-(void) testArgumentObjectsCretedCorrectlyForBlock
+{
+    //Given
+    NSMethodSignature* signature = [[TestClass new] methodSignatureForSelector:@selector(setNumber:object:block:)];
+    
+    //When
+    void(^block)(id,...) = [DixieRunTimeHelper blockForSignature:signature block:^(id victim, DixieCallEnvironment *environment) {
+    
+        //Then
+        XCTAssert([environment.arguments[0] intValue] == 2, @"First parameter should be an int");
+        XCTAssert([environment.arguments[1] isEqualToNumber:@2], @"Second parameter should be an int");
+        BOOL(^thirdParameter)(void) = environment.arguments[2];
+        XCTAssert(thirdParameter(), @"Third parameter should be a block");
+    }];
+    
+    //For blocks, do NOT send the selector
+    block([TestClass new],2,@2,[^{return YES;} copy]);
+}
+
 -(void) testVoidBlockReturned
 {
     //Given
@@ -167,14 +186,36 @@
     
     //When
     id(^block)(id, ...) = [DixieRunTimeHelper blockForSignature:signature block:^(id victim, DixieCallEnvironment *environment) {
-        environment.returnValue = @2;
+        environment.returnValue = (__bridge void *)(@2);
     }];
     
     //Then
     @try {
         id returnValue = block([TestClass new], @selector(returnValue));
         
-        XCTAssert([returnValue isEqualToNumber:@2], @"Correct value should be returned");
+        XCTAssert([returnValue isEqualToNumber:@2], @"Correct id value should be returned");
+    }
+    @catch (NSException *exception) {
+        XCTFail(@"Correct void block should be returned");
+    }
+}
+
+-(void) testIntReturnBlockReturned
+{
+    //Given
+    NSMethodSignature* signature = [[TestClass new] methodSignatureForSelector:@selector(returnIntValue)];
+    
+    //When
+    int intValue = 11;
+    int(^block)(id, ...) = [DixieRunTimeHelper blockForSignature:signature block:^(id victim, DixieCallEnvironment *environment) {
+        environment.returnValue = (void *)&intValue;
+    }];
+    
+    //Then
+    @try {
+        int returnValue = block([TestClass new], @selector(returnValue));
+        
+        XCTAssert(returnValue == 11, @"Correct int value should be returned");
     }
     @catch (NSException *exception) {
         XCTFail(@"Correct void block should be returned");

--- a/Dixie/DixieTests/Units/RunTimeHelperTests.m
+++ b/Dixie/DixieTests/Units/RunTimeHelperTests.m
@@ -228,7 +228,6 @@
     Class testClass = [TestClass class];
     NSArray* expectedSelector = @[
                                   NSStringFromSelector(@selector(doNothing)),
-                                  NSStringFromSelector(@selector(throwException)),
                                   NSStringFromSelector(@selector(returnValue)),
                                   NSStringFromSelector(@selector(setChar:frame:))
                                   ];
@@ -277,7 +276,7 @@
     Class returnedInstanceClass = [DixieRunTimeHelper classForMethodInfo:instanceInfo];
     
     //Then
-    XCTAssert(returnedClass != returnedInstanceClass, @"Class method should ahve different target class");
+    XCTAssert(returnedClass != returnedInstanceClass, @"Class method should have different target class");
 }
 
 @end

--- a/DixieExampleApp/DixieExampleApp/Info.plist
+++ b/DixieExampleApp/DixieExampleApp/Info.plist
@@ -32,6 +32,11 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Checks the parameters of the method and if one matches the value of a given `Dix
 The idea of changing an object's behaviour is not new. It is usually used in unit testing, where a component's dependencies are mocked to have a controlled, reproducible environment. In these situations there is the requirement that the target project should be _easily injectable_. If you are depending on components that are not made by you, or that are not injectable, you have to turn to different methods. To implement the theory of creating chaos/altering component behaviour in Objective-C environment, Dixie uses the technique of _Method Swizzling_. Method swizzling relies on calling special runtime methods, that require knowing the target method and its environment. Dixie takes care of handling the runtime for you, and also hides the original method environment, so you only have to focus on defining the new behaviour and can apply it quickly and simply.
 
 __Note:__ 
-* The current implementation is best at changing behaviours of methods that are expecting object as parameters and that either return `void` or object. Support for primitive types will come in the next version.
+* The current implementation is best at changing behaviours of methods on iOS simulator. Support for arm architectures will come in the next version.
 * Dixie is best for testing so, as with other similar libraries, its usage in production environments is strongly discouraged.
 
 


### PR DESCRIPTION
Added support for most used primitive types:
- Turned on original value storage
- Created macro for different block wrapper implementation
- Logger will only log objects (for now)
- DixieCallEnvironment: using `void*` instead of `id` for returnValue
- added unit tests for as many method variation as we could think of

Fixed multiple parameter parsing problem:
- passing `va_list` by reference (passing it by value copied the state and the parsing method read always the first element)

Validated with the contribution guideline:
- Updated read.me and Example app to support iOS9
